### PR TITLE
Update docker resolver with support for redirects

### DIFF
--- a/docker/docker_client.go
+++ b/docker/docker_client.go
@@ -545,6 +545,18 @@ func (c *dockerClient) makeRequestToResolvedURLOnce(ctx context.Context, method,
 			return nil, err
 		}
 	}
+	if c.client.CheckRedirect == nil {
+		c.client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			logrus.Debugf("Redirecting host to %s", req.URL.Host)
+			if len(via) >= 10 {
+				return errors.New("stopped after 10 redirects")
+			}
+			if auth == v2Auth {
+				return errors.Wrap(c.setupRequestAuth(req, extraScope), "failed to authorize redirect")
+			}
+			return nil
+		}
+	}
 	logrus.Debugf("%s %s", method, url)
 	res, err := c.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Authorizes the request in case the host is redirected, supporting at most 10 redirects.
Inspired in the containerd's implementation for supporting redirects.
https://github.com/containerd/containerd/commit/b1d4140a220eb429eeb2059cd33fad6cd3bc7c80

Signed-off-by: Fabio Luz <fabio.luz@scarf.sh>